### PR TITLE
Tables: Use three hyphens in tables instead of one

### DIFF
--- a/src/action-docs.ts
+++ b/src/action-docs.ts
@@ -176,7 +176,7 @@ function getInputOutput(
     type === "input"
       ? ["parameter", "description", "required", "default"]
       : ["parameter", "description"];
-  headers[1] = Array(headers[0].length).fill("-");
+  headers[1] = Array(headers[0].length).fill("---");
 
   for (let i = 0; i < Object.keys(data).length; i++) {
     const key = Object.keys(data)[i];


### PR DESCRIPTION
In order to follow the GitHub specification for tables, we want to use 3 hyphens to separate table header row from the data rows.

Refs https://github.com/npalm/action-docs/issues/275